### PR TITLE
Add Windbird stations 2001 and 2039 data to balises page

### DIFF
--- a/app/balises/balises.module.scss
+++ b/app/balises/balises.module.scss
@@ -1,5 +1,11 @@
 .mesures-tab-page {
     text-align: center;
+
+    .wind-data-attribution {
+        font-size: 0.75em;
+        opacity: 0.7;
+        margin-top: 0.5em;
+    }
     img {
         width: 100%;
         height: auto;

--- a/app/balises/components/GenericMeters/GenericMeterCard.tsx
+++ b/app/balises/components/GenericMeters/GenericMeterCard.tsx
@@ -57,13 +57,15 @@ const GenericMeterCard: React.FC<GenericMeterCardProps> = ({
                     )}
                 </div>
                 <div className={'balise-infos-card--metering'}>
-                    <div className="balise-infos-card--meter">
-                        <FontAwesomeIcon icon={faTemperatureThreeQuarters} />
-                        <div className="meter-value">
-                            {meterData.temperature}
-                            <span className="meter-unit">&deg;C</span>
+                    {meterData.temperature !== undefined && (
+                        <div className="balise-infos-card--meter">
+                            <FontAwesomeIcon icon={faTemperatureThreeQuarters} />
+                            <div className="meter-value">
+                                {meterData.temperature}
+                                <span className="meter-unit">&deg;C</span>
+                            </div>
                         </div>
-                    </div>
+                    )}
                     {meterData.humidity && (
                         <div className="balise-infos-card--meter">
                             <FontAwesomeIcon icon={faDroplet} />

--- a/app/balises/components/Mesures/SharedMeasureGraph.tsx
+++ b/app/balises/components/Mesures/SharedMeasureGraph.tsx
@@ -10,13 +10,14 @@ import {
     numericHalfWindSegment,
 } from 'services/wind/OrientationMapper';
 import { BasicTooltip } from '@nivo/tooltip';
-import { WINBIRD_STATIONS } from 'services/winbird/fetchWindbird';
+import {
+    WINBIRD_COLORS,
+    WINBIRD_STATIONS,
+} from 'services/winbird/fetchWindbird';
 
 type SharedMeasureGraphProps = {
     windData: WindData;
 };
-
-const WINBIRD_COLORS = ['#3f9fff', '#8f7fff'];
 
 const getColorById = (series: { id: string }) => {
     switch (series.id) {
@@ -115,9 +116,9 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             justify: false,
                             translateX: 0,
                             translateY: -35,
-                            itemsSpacing: 8,
+                            itemsSpacing: 6,
                             itemDirection: 'left-to-right',
-                            itemWidth: 80,
+                            itemWidth: 95,
                             itemHeight: 20,
                             itemOpacity: 0.75,
                             symbolSize: 12,
@@ -194,9 +195,9 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             justify: false,
                             translateX: 0,
                             translateY: -35,
-                            itemsSpacing: 8,
+                            itemsSpacing: 6,
                             itemDirection: 'left-to-right',
-                            itemWidth: 80,
+                            itemWidth: 95,
                             itemHeight: 20,
                             itemOpacity: 0.75,
                             symbolSize: 12,

--- a/app/balises/components/Mesures/SharedMeasureGraph.tsx
+++ b/app/balises/components/Mesures/SharedMeasureGraph.tsx
@@ -26,7 +26,7 @@ const getColorById = (series: { id: string }) => {
             return '#ffcb1e'; // Green for Holfuy average
         default:
             const winbirdIndex = WINBIRD_STATIONS.findIndex(
-                (station) => station.name === series.id,
+                (station) => station.shortName === series.id,
             );
             if (winbirdIndex !== -1) {
                 return WINBIRD_COLORS[winbirdIndex];
@@ -82,7 +82,7 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             (e) => e != undefined && e.data.length > 0,
                         ) as Array<GraphData>
                     }
-                    margin={{ top: 30, right: 50, bottom: 30, left: 10 }}
+                    margin={{ top: 60, right: 50, bottom: 30, left: 10 }}
                     xScale={{ format: '%Y-%m-%dT%H:%M:%S.%L%Z', type: 'time' }}
                     xFormat="time:%Hh%M"
                     yScale={{ type: 'linear' }}
@@ -114,10 +114,10 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             direction: 'row',
                             justify: false,
                             translateX: 0,
-                            translateY: -25,
-                            itemsSpacing: 0,
+                            translateY: -35,
+                            itemsSpacing: 8,
                             itemDirection: 'left-to-right',
-                            itemWidth: 100,
+                            itemWidth: 80,
                             itemHeight: 20,
                             itemOpacity: 0.75,
                             symbolSize: 12,
@@ -148,7 +148,7 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             (e) => e != undefined && e.data.length > 0,
                         ) as Array<GraphData>
                     }
-                    margin={{ top: 30, right: 50, bottom: 30, left: 10 }}
+                    margin={{ top: 60, right: 50, bottom: 30, left: 10 }}
                     xScale={{ format: '%Y-%m-%dT%H:%M:%S.%L%Z', type: 'time' }}
                     xFormat="time:%Hh%M"
                     yScale={{
@@ -193,10 +193,10 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                             direction: 'row',
                             justify: false,
                             translateX: 0,
-                            translateY: -25,
-                            itemsSpacing: 0,
+                            translateY: -35,
+                            itemsSpacing: 8,
                             itemDirection: 'left-to-right',
-                            itemWidth: 100,
+                            itemWidth: 80,
                             itemHeight: 20,
                             itemOpacity: 0.75,
                             symbolSize: 12,

--- a/app/balises/components/Mesures/SharedMeasureGraph.tsx
+++ b/app/balises/components/Mesures/SharedMeasureGraph.tsx
@@ -10,10 +10,13 @@ import {
     numericHalfWindSegment,
 } from 'services/wind/OrientationMapper';
 import { BasicTooltip } from '@nivo/tooltip';
+import { WINBIRD_STATIONS } from 'services/winbird/fetchWindbird';
 
 type SharedMeasureGraphProps = {
     windData: WindData;
 };
+
+const WINBIRD_COLORS = ['#3f9fff', '#8f7fff'];
 
 const getColorById = (series: { id: string }) => {
     switch (series.id) {
@@ -22,6 +25,12 @@ const getColorById = (series: { id: string }) => {
         case 'Holfuy':
             return '#ffcb1e'; // Green for Holfuy average
         default:
+            const winbirdIndex = WINBIRD_STATIONS.findIndex(
+                (station) => station.name === series.id,
+            );
+            if (winbirdIndex !== -1) {
+                return WINBIRD_COLORS[winbirdIndex];
+            }
             return '#' + Math.floor(Math.random() * 16777215).toString(16); // Random color fallback
     }
 };
@@ -65,6 +74,7 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                         [
                             windData.graph.windSpeed.opgc,
                             windData.graph.windSpeed.holfuy,
+                            ...(windData.graph.windSpeed.winbird || []),
                             // windData.graph.windSpeed.labuse,
                             // windData.graph.windSpeed.holfuyMax,
                             // windData.graph.windSpeed.holfuyMin,
@@ -132,6 +142,7 @@ const SharedMeasureGraph: React.FC<SharedMeasureGraphProps> = ({
                         [
                             windData.graph.windDirection.opgc,
                             windData.graph.windDirection.holfuy,
+                            ...(windData.graph.windDirection.winbird || []),
                             // windData.graph.windDirection.labuse,
                         ].filter(
                             (e) => e != undefined && e.data.length > 0,

--- a/app/balises/components/Mesures/SharedMeasures.tsx
+++ b/app/balises/components/Mesures/SharedMeasures.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import './sharedMeasure.scss';
 import GenericMeterCardTitle from '../GenericMeters/GenericMeterCardTitle';
 import {
-    OPEN_WIND_MAP_URL,
     WINBIRD_COLORS,
     WINBIRD_STATIONS,
 } from 'services/winbird/fetchWindbird';
@@ -48,7 +47,7 @@ const SharedMeasure: React.FC<SharedMeasureProps> = async () => {
                     return (
                         <Link
                             key={station.id}
-                            href={OPEN_WIND_MAP_URL}
+                            href={station.detailUrl}
                             className="meter-columns"
                         >
                             <GenericMeterCardTitle hasLink>

--- a/app/balises/components/Mesures/SharedMeasures.tsx
+++ b/app/balises/components/Mesures/SharedMeasures.tsx
@@ -6,6 +6,10 @@ import Link from 'next/link';
 
 import './sharedMeasure.scss';
 import GenericMeterCardTitle from '../GenericMeters/GenericMeterCardTitle';
+import {
+    OPEN_WIND_MAP_URL,
+    WINBIRD_STATIONS,
+} from 'services/winbird/fetchWindbird';
 
 type SharedMeasureProps = {};
 
@@ -35,6 +39,27 @@ const SharedMeasure: React.FC<SharedMeasureProps> = async () => {
                         <GenericMeterCard meterData={windData.opgcLive} />
                     </div>
                 )}
+                {WINBIRD_STATIONS.map((station, index) => {
+                    const liveData = windData.winbirdLive[index];
+                    if (!liveData) {
+                        return null;
+                    }
+                    return (
+                        <Link
+                            key={station.id}
+                            href={OPEN_WIND_MAP_URL}
+                            className="meter-columns"
+                        >
+                            <GenericMeterCardTitle hasLink>
+                                {station.name}
+                            </GenericMeterCardTitle>
+                            <GenericMeterCard
+                                meterData={liveData}
+                                color={'#3f9fff'}
+                            />
+                        </Link>
+                    );
+                })}
                 {/* {windData.labuseLive && (
                     <Link
                         href={'https://labuse.uiguig.ovh/devices/2'}

--- a/app/balises/components/Mesures/SharedMeasures.tsx
+++ b/app/balises/components/Mesures/SharedMeasures.tsx
@@ -8,6 +8,7 @@ import './sharedMeasure.scss';
 import GenericMeterCardTitle from '../GenericMeters/GenericMeterCardTitle';
 import {
     OPEN_WIND_MAP_URL,
+    WINBIRD_COLORS,
     WINBIRD_STATIONS,
 } from 'services/winbird/fetchWindbird';
 
@@ -55,7 +56,7 @@ const SharedMeasure: React.FC<SharedMeasureProps> = async () => {
                             </GenericMeterCardTitle>
                             <GenericMeterCard
                                 meterData={liveData}
-                                color={'#3f9fff'}
+                                color={WINBIRD_COLORS[index]}
                             />
                         </Link>
                     );

--- a/app/balises/page.tsx
+++ b/app/balises/page.tsx
@@ -37,6 +37,12 @@ const BalisesPage: React.FC<BalisesPageProps> = () => {
         >
             {/* <WarningHelico /> */}
             <SharedMeasure />
+            <p className={balisesPageStyles['wind-data-attribution']}>
+                Données vent (c) contributeurs du réseau OpenWindMap{' '}
+                <a href="https://openwindmap.org" target="_blank">
+                    openwindmap.org
+                </a>
+            </p>
             {/*
             <div>
                 <div className="text-alert">

--- a/services/opgc/apiGrafanaOPGC.ts
+++ b/services/opgc/apiGrafanaOPGC.ts
@@ -111,7 +111,7 @@ export async function fetchWindHistoryFromGrafana(): Promise<OPGCWindHistory | n
     const query = {
         // See the attached file to edit the queries
         queries: grafanaHistoryQueries,
-        from: `${time.minus({ hours: 3 }).toMillis()}`,
+        from: `${time.minus({ hours: 6 }).toMillis()}`,
         to: `${time.toMillis()}`,
     };
 

--- a/services/winbird/__tests__/fetchWindbird.test.ts
+++ b/services/winbird/__tests__/fetchWindbird.test.ts
@@ -1,0 +1,156 @@
+import {
+    convertWindbirdArchiveToGeneric,
+    convertWindbirdLiveToGeneric,
+    WindbirdArchiveResponse,
+    WindbirdLiveResponse,
+} from '../fetchWindbird';
+
+describe('Testing convertWindbirdLiveToGeneric', () => {
+    it('should convert a live measurement to a generic one', () => {
+        const liveResponse: WindbirdLiveResponse = {
+            data: {
+                id: 1593,
+                meta: {
+                    name: 'Windbird 1593',
+                },
+                location: {
+                    latitude: 44.502391,
+                    longitude: 3.307975,
+                    date: '2026-08-03T20:20:52.000Z',
+                    success: true,
+                },
+                measurements: {
+                    date: '2026-08-03T20:25:52.000Z',
+                    pressure: null,
+                    wind_heading: 247.5,
+                    wind_speed_avg: 14,
+                    wind_speed_max: 21.5,
+                    wind_speed_min: 6,
+                },
+                status: {
+                    date: '2026-08-03T20:25:52.000Z',
+                    snr: 21.5,
+                    state: 'on',
+                },
+            },
+        };
+
+        const result = convertWindbirdLiveToGeneric(liveResponse);
+
+        expect(result).toStrictEqual({
+            datetime: '2026-08-03T20:25:52.000Z',
+            wind: {
+                speed: 14,
+                gust: 21.5,
+                min: 6,
+                direction: 247.5,
+            },
+        });
+    });
+
+    it('should throw on invalid timestamp', () => {
+        const liveResponse: WindbirdLiveResponse = {
+            data: {
+                id: 1593,
+                meta: {
+                    name: 'Windbird 1593',
+                },
+                location: {
+                    latitude: 44.502391,
+                    longitude: 3.307975,
+                    date: null,
+                    success: true,
+                },
+                measurements: {
+                    date: 'not-a-date',
+                    pressure: null,
+                    wind_heading: 247.5,
+                    wind_speed_avg: 14,
+                    wind_speed_max: 21.5,
+                    wind_speed_min: 6,
+                },
+                status: {
+                    date: '2026-08-03T20:25:52.000Z',
+                    snr: 21.5,
+                    state: 'on',
+                },
+            },
+        };
+
+        expect(() => convertWindbirdLiveToGeneric(liveResponse)).toThrow(
+            'Invalid timestamp',
+        );
+    });
+});
+
+describe('Testing convertWindbirdArchiveToGeneric', () => {
+    const archiveResponse: WindbirdArchiveResponse = {
+        legend: [
+            'time',
+            'latitude',
+            'longitude',
+            'wind_speed_min',
+            'wind_speed_avg',
+            'wind_speed_max',
+            'wind_heading',
+            'pressure',
+        ],
+        units: [
+            'utc',
+            'degrees',
+            'degrees',
+            'km/h',
+            'km/h',
+            'km/h',
+            'degrees',
+            '(deprecated)',
+        ],
+        data: [
+            [
+                '2026-08-03T20:15:49.000Z',
+                44.502391,
+                3.307975,
+                14,
+                21.5,
+                29,
+                225,
+                null,
+            ],
+            [
+                '2026-08-03T20:20:52.000Z',
+                44.502391,
+                3.307975,
+                8,
+                14,
+                21.5,
+                247.5,
+                null,
+            ],
+        ],
+    };
+
+    it('should convert archive measurements to generic ones', () => {
+        const result = convertWindbirdArchiveToGeneric(archiveResponse);
+
+        expect(result).toStrictEqual([
+            {
+                datetime: '2026-08-03T20:15:49.000Z',
+                wind: {
+                    speed: 21.5,
+                    gust: 29,
+                    min: 14,
+                    direction: 225,
+                },
+            },
+            {
+                datetime: '2026-08-03T20:20:52.000Z',
+                wind: {
+                    speed: 14,
+                    gust: 21.5,
+                    min: 8,
+                    direction: 247.5,
+                },
+            },
+        ]);
+    });
+});

--- a/services/winbird/fetchWindbird.ts
+++ b/services/winbird/fetchWindbird.ts
@@ -7,10 +7,12 @@ export const WINBIRD_STATIONS = [
     {
         id: 2001,
         name: 'Décollage Mont Chouvé 1450m',
+        shortName: 'Mont Chouvé',
     },
     {
         id: 2039,
         name: 'Cornillon JOB 1130m',
+        shortName: 'Cornillon JOB',
     },
 ] as const;
 

--- a/services/winbird/fetchWindbird.ts
+++ b/services/winbird/fetchWindbird.ts
@@ -1,0 +1,157 @@
+import { DateTime } from 'luxon';
+import { GenericWindMeasurement } from 'services/wind/GenericWindMeasurement';
+
+export const OPEN_WIND_MAP_URL = 'https://openwindmap.org';
+
+export const WINBIRD_STATIONS = [
+    {
+        id: 2001,
+        name: 'Décollage Mont Chouvé 1450m',
+    },
+    {
+        id: 2039,
+        name: 'Cornillon JOB 1130m',
+    },
+] as const;
+
+export type WindbirdLiveResponse = {
+    data: {
+        id: number;
+        meta: {
+            name: string;
+        };
+        location: {
+            latitude: number;
+            longitude: number;
+            date: string | null;
+            success: boolean;
+        };
+        measurements: {
+            date: string;
+            pressure: number | null;
+            wind_heading: number | null;
+            wind_speed_avg: number | null;
+            wind_speed_max: number | null;
+            wind_speed_min: number | null;
+        };
+        status: {
+            date: string;
+            snr: number | null;
+            state: 'on' | 'off' | null;
+        };
+    };
+};
+
+export type WindbirdArchiveResponse = {
+    legend: Array<string>;
+    units: Array<string>;
+    data: Array<
+        [
+            string,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number | null,
+        ]
+    >;
+};
+
+export async function fetchWindbirdLive(
+    stationId: number,
+): Promise<WindbirdLiveResponse> {
+    const results = await fetch(
+        `https://api.pioupiou.fr/v1/live/${stationId}`,
+        {
+            method: 'GET',
+            next: {
+                revalidate: 60,
+            },
+        },
+    );
+
+    if (!results.ok) {
+        throw new Error(`Error fetching winbird live data: ${results.status}`);
+    }
+
+    return results.json();
+}
+
+export async function fetchWindbirdHistory(
+    stationId: number,
+): Promise<WindbirdArchiveResponse> {
+    const results = await fetch(
+        `https://api.pioupiou.fr/v1/archive/${stationId}?start=last-day&stop=now`,
+        {
+            method: 'GET',
+            next: {
+                revalidate: 60,
+            },
+        },
+    );
+
+    if (!results.ok) {
+        throw new Error(
+            `Error fetching winbird archive data: ${results.status}`,
+        );
+    }
+
+    return results.json();
+}
+
+export function convertWindbirdLiveToGeneric(
+    liveResponse: WindbirdLiveResponse,
+): GenericWindMeasurement {
+    const { measurements } = liveResponse.data;
+
+    const datetime = DateTime.fromISO(measurements.date, { zone: 'utc' });
+
+    if (!datetime.isValid) {
+        throw new Error('Invalid timestamp');
+    }
+
+    return {
+        datetime: datetime.toISO(),
+        wind: {
+            speed: measurements.wind_speed_avg as number,
+            gust: measurements.wind_speed_max as number,
+            min: measurements.wind_speed_min as number,
+            direction: measurements.wind_heading as number,
+        },
+    };
+}
+
+export function convertWindbirdArchiveToGeneric(
+    archiveResponse: WindbirdArchiveResponse,
+): Array<GenericWindMeasurement> {
+    const windSpeedAvgIndex = archiveResponse.legend.indexOf(
+        'wind_speed_avg',
+    );
+    const windSpeedMaxIndex = archiveResponse.legend.indexOf(
+        'wind_speed_max',
+    );
+    const windSpeedMinIndex = archiveResponse.legend.indexOf(
+        'wind_speed_min',
+    );
+    const windHeadingIndex = archiveResponse.legend.indexOf('wind_heading');
+
+    return archiveResponse.data.map((entry) => {
+        const datetime = DateTime.fromISO(entry[0], { zone: 'utc' });
+
+        if (!datetime.isValid) {
+            throw new Error('Invalid timestamp');
+        }
+
+        return {
+            datetime: datetime.toISO(),
+            wind: {
+                speed: entry[windSpeedAvgIndex] as number,
+                gust: entry[windSpeedMaxIndex] as number,
+                min: entry[windSpeedMinIndex] as number,
+                direction: entry[windHeadingIndex] as number,
+            },
+        };
+    });
+}

--- a/services/winbird/fetchWindbird.ts
+++ b/services/winbird/fetchWindbird.ts
@@ -12,11 +12,13 @@ export const WINBIRD_STATIONS = [
         id: 2001,
         name: 'Décollage Mont Chouvé 1450m',
         shortName: 'Mont Chouvé',
+        detailUrl: 'https://www.openwindmap.org/windbird-2001',
     },
     {
         id: 2039,
         name: 'Cornillon JOB 1130m',
         shortName: 'Cornillon JOB',
+        detailUrl: 'https://www.openwindmap.org/windbird-2039',
     },
 ] as const;
 

--- a/services/winbird/fetchWindbird.ts
+++ b/services/winbird/fetchWindbird.ts
@@ -3,6 +3,10 @@ import { GenericWindMeasurement } from 'services/wind/GenericWindMeasurement';
 
 export const OPEN_WIND_MAP_URL = 'https://openwindmap.org';
 
+export const WINBIRD_COLORS = ['#3f9fff', '#8f7fff'] as const;
+
+export const WINBIRD_HISTORY_HOURS = 6;
+
 export const WINBIRD_STATIONS = [
     {
         id: 2001,
@@ -61,22 +65,39 @@ export type WindbirdArchiveResponse = {
     >;
 };
 
-export async function fetchWindbirdLive(
-    stationId: number,
-): Promise<WindbirdLiveResponse> {
-    const results = await fetch(
-        `https://api.pioupiou.fr/v1/live/${stationId}`,
-        {
+async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+        }
+
+        const results = await fetch(url, {
             method: 'GET',
             next: {
                 revalidate: 60,
             },
-        },
-    );
+        });
 
-    if (!results.ok) {
-        throw new Error(`Error fetching winbird live data: ${results.status}`);
+        if (results.ok) {
+            return results;
+        }
+
+        lastError = new Error(
+            `Error fetching winbird data: ${results.status}`,
+        );
     }
+
+    throw lastError;
+}
+
+export async function fetchWindbirdLive(
+    stationId: number,
+): Promise<WindbirdLiveResponse> {
+    const results = await fetchWithRetry(
+        `https://api.pioupiou.fr/v1/live/${stationId}`,
+    );
 
     return results.json();
 }
@@ -84,21 +105,15 @@ export async function fetchWindbirdLive(
 export async function fetchWindbirdHistory(
     stationId: number,
 ): Promise<WindbirdArchiveResponse> {
-    const results = await fetch(
-        `https://api.pioupiou.fr/v1/archive/${stationId}?start=last-day&stop=now`,
-        {
-            method: 'GET',
-            next: {
-                revalidate: 60,
-            },
-        },
-    );
+    const start = DateTime.now()
+        .toUTC()
+        .minus({ hours: WINBIRD_HISTORY_HOURS })
+        .toISO();
+    const stop = DateTime.now().toUTC().toISO();
 
-    if (!results.ok) {
-        throw new Error(
-            `Error fetching winbird archive data: ${results.status}`,
-        );
-    }
+    const results = await fetchWithRetry(
+        `https://api.pioupiou.fr/v1/archive/${stationId}?start=${start}&stop=${stop}`,
+    );
 
     return results.json();
 }

--- a/services/wind/GenericWindMeasurement.ts
+++ b/services/wind/GenericWindMeasurement.ts
@@ -6,7 +6,7 @@ export type GenericWindMeasurement = {
         min?: number;
         direction: number;
     };
-    temperature: number;
+    temperature?: number;
     humidity?: number;
     pressure?: number;
 };

--- a/services/wind/windDataFetching.ts
+++ b/services/wind/windDataFetching.ts
@@ -15,11 +15,19 @@ import {
 } from 'services/opgc/synthetized-txt-files';
 import { GenericWindMeasurement } from './GenericWindMeasurement';
 import { getLabuseData } from 'services/labuse/labuseService';
+import {
+    convertWindbirdArchiveToGeneric,
+    convertWindbirdLiveToGeneric,
+    fetchWindbirdHistory,
+    fetchWindbirdLive,
+    WINBIRD_STATIONS,
+} from 'services/winbird/fetchWindbird';
 
 export type WindData = {
     opgcLive: GenericWindMeasurement | null;
     holfuyLive: GenericWindMeasurement | null;
     labuseLive: GenericWindMeasurement | null;
+    winbirdLive: Array<GenericWindMeasurement | null>;
     graph: {
         windSpeed: {
             opgc?: GraphData;
@@ -27,11 +35,13 @@ export type WindData = {
             holfuyMax?: GraphData;
             holfuyMin?: GraphData;
             labuse?: GraphData;
+            winbird?: Array<GraphData>;
         };
         windDirection: {
             opgc?: GraphData;
             holfuy?: GraphData;
             labuse?: GraphData;
+            winbird?: Array<GraphData>;
         };
     };
 };
@@ -43,6 +53,7 @@ export async function fetchAllWindData(): Promise<WindData> {
         maxWind,
         holfuyArchive,
         labuseGenericData,
+        winbirdData,
     ] = await Promise.all([
         fetchWindHistoryFromGrafana().catch((e) => {
             console.error('Error fetching wind history from grafana');
@@ -68,6 +79,11 @@ export async function fetchAllWindData(): Promise<WindData> {
         //     return null;
         // }),
         Promise.resolve(null),
+        fetchAllWinbirdData().catch((e) => {
+            console.error('Error fetching winbird data');
+            console.error(e);
+            return null;
+        }),
     ]);
 
     // Fallback try to get last file
@@ -157,10 +173,15 @@ export async function fetchAllWindData(): Promise<WindData> {
     const labuseGraphWind = undefined;
     const labuseGraphOrientation = undefined;
 
+    const winbirdLive = winbirdData?.live || [];
+    const winbirdGraphWind = winbirdData?.graphWindSpeed;
+    const winbirdGraphDirection = winbirdData?.graphWindDirection;
+
     return {
         opgcLive: uOpgcLive,
         holfuyLive: uHolfuyLive,
         labuseLive,
+        winbirdLive,
         graph: {
             windSpeed: {
                 opgc: graphOPGCwind,
@@ -168,12 +189,74 @@ export async function fetchAllWindData(): Promise<WindData> {
                 holfuyMax: graphHolfuyWindMax,
                 holfuyMin: graphHolfuyWindMin,
                 labuse: labuseGraphWind,
+                winbird: winbirdGraphWind,
             },
             windDirection: {
                 opgc: graphOPGCDirection,
                 holfuy: graphHolfuyDirection,
                 labuse: labuseGraphOrientation,
+                winbird: winbirdGraphDirection,
             },
         },
+    };
+}
+
+type AllWinbirdData = {
+    live: Array<GenericWindMeasurement | null>;
+    graphWindSpeed: Array<GraphData>;
+    graphWindDirection: Array<GraphData>;
+};
+
+async function fetchAllWinbirdData(): Promise<AllWinbirdData> {
+    const stationsData = await Promise.all(
+        WINBIRD_STATIONS.map(async (station) => {
+            const [live, archive] = await Promise.all([
+                fetchWindbirdLive(station.id).catch((e) => {
+                    console.error(
+                        `Error fetching winbird ${station.id} live`,
+                    );
+                    console.error(e);
+                    return null;
+                }),
+                fetchWindbirdHistory(station.id).catch((e) => {
+                    console.error(
+                        `Error fetching winbird ${station.id} history`,
+                    );
+                    console.error(e);
+                    return null;
+                }),
+            ]);
+
+            const history =
+                archive && archive.data.length > 0
+                    ? convertWindbirdArchiveToGeneric(archive)
+                    : [];
+
+            return {
+                name: station.name,
+                live: live
+                    ? convertWindbirdLiveToGeneric(live)
+                    : null,
+                history,
+            };
+        }),
+    );
+
+    return {
+        live: stationsData.map((station) => station.live),
+        graphWindSpeed: stationsData.map((station) => ({
+            id: station.name,
+            data: station.history.map((measurement) => ({
+                x: measurement.datetime,
+                y: measurement.wind.speed,
+            })),
+        })),
+        graphWindDirection: stationsData.map((station) => ({
+            id: station.name,
+            data: station.history.map((measurement) => ({
+                x: measurement.datetime,
+                y: measurement.wind.direction,
+            })),
+        })),
     };
 }

--- a/services/wind/windDataFetching.ts
+++ b/services/wind/windDataFetching.ts
@@ -233,7 +233,7 @@ async function fetchAllWinbirdData(): Promise<AllWinbirdData> {
                     : [];
 
             return {
-                name: station.name,
+                shortName: station.shortName,
                 live: live
                     ? convertWindbirdLiveToGeneric(live)
                     : null,
@@ -245,14 +245,14 @@ async function fetchAllWinbirdData(): Promise<AllWinbirdData> {
     return {
         live: stationsData.map((station) => station.live),
         graphWindSpeed: stationsData.map((station) => ({
-            id: station.name,
+            id: station.shortName,
             data: station.history.map((measurement) => ({
                 x: measurement.datetime,
                 y: measurement.wind.speed,
             })),
         })),
         graphWindDirection: stationsData.map((station) => ({
-            id: station.name,
+            id: station.shortName,
             data: station.history.map((measurement) => ({
                 x: measurement.datetime,
                 y: measurement.wind.direction,


### PR DESCRIPTION
## Objectif
Intégrer les données des deux balises **Windbird** (stations 2001 « Décollage Mont Chouvé 1450m » et 2039 « Cornillon JOB 1130m ») sur la page Balises.

## API
Les balises Windbird partagent leurs données via l'API publique **Pioupiou/OpenWindMap** (\pi.pioupiou.fr/v1\) — **aucune clé API requise** (licence communautaire gratuite).

## Changements
- **\services/winbird/fetchWindbird.ts\** (nouveau) : fetch \live\ + \rchive\ (dernier jour), convertisseurs vers \GenericWindMeasurement\, IDs des stations en constantes \WINBIRD_STATIONS\.
- **\GenericWindMeasurement\** : \	emperature\ devient optionnelle (les Windbird ne mesurent que le vent) ; \GenericMeterCard\ masque le thermomètre si absent.
- **\windDataFetching.ts\** : récupération live + historique des 2 stations (pattern labuse).
- **Page Balises** : 2 cartes de mesure + séries sur les graphes vent/direction partagés.
- **Attribution** : lien visible vers openwindmap.org (requis par la licence de données).

## Vérifications
- \yarn typecheck\ ✅ · \jest\ 69/69 ✅ · \yarn build\ ✅
- Appels API validés en conditions réelles (live 2001/2039, archive).

## À noter
- Les données Holfuy étant protégées par mot de passe, la licence communautaire OpenWindMap (qui impose que les autres capteurs de l'app soient *open*) pourrait nécessiter une **Extended License** — à confirmer avec openwindmap.org.